### PR TITLE
Remove splash_screens and add screenshots members

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ $ npm install --save-dev app-manifest-loader
 
 ## Web App Manifest
 
-Re-References all images declared in the `icons` and `splash_screens` fields.
+Re-References all images declared in the `icons` and `screenshots` fields.
 
 Here you'll find additional documentation on the corresponding standard:
 
@@ -105,9 +105,9 @@ The manifest allows you to provide image paths in the standard Webpack format in
 {
   "name": "Hello World",
   ...
-  "splash_screens": [
+  "screenshots": [
     {
-      "src": "./images/splash-hi.png",
+      "src": "./images/screenshot-portrait.png",
       "sizes": "2560x1440",
       "type": "image/png"
     },
@@ -115,8 +115,8 @@ The manifest allows you to provide image paths in the standard Webpack format in
   ],
   "icons": [
     {
-      "src": "./images/icon-hi.png",
-      "sizes": "512x512",
+      "src": "./images/screenshot-landscape.png",
+      "sizes": "1440x2560",
       "type": "image/png"
     },
     ...

--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ export default async function(content, map, meta) {
 
     try {
       await Promise.all([
-        resolveImages.call(this, manifest.splash_screens, options),
+        resolveImages.call(this, manifest.screenshots, options),
         resolveImages.call(this, manifest.icons, options)
       ])
     } catch(resolveError) {


### PR DESCRIPTION
As `splash_screens` member is not part of the spec anymore, it's usage is discourages and the documentation referring to it has also been removed from MDN.

Also, `screenshots` are part of the specification but currently the loader does not support them.

##### References
w3: https://www.w3.org/TR/appmanifest
Mozilla bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?format=default&id=1262739

##### Notes
Haven't changed the tests, they can be updated on this same pull request.